### PR TITLE
More URI attributes identified and Throw error/warning on scriptable tags

### DIFF
--- a/src/context-parser-handlebars.js
+++ b/src/context-parser-handlebars.js
@@ -51,7 +51,6 @@ var filter = {
 ')*'].join('');
 */
 var reURIContextStartWhitespaces = /^(?:[\u0000-\u0020]|&#[xX]0*(?:1?[1-9a-fA-F]|10|20);?|&#0*(?:[1-9]|[1-2][0-9]|30|31|32);?|&Tab;|&NewLine;)*/;
-var uriAttributeNames = {'href':1, 'src':1, 'action':1, 'formaction':1, 'background':1, 'cite':1, 'longdesc':1, 'usemap':1, 'poster':1, 'xlink:href':1};
 var reEqualSign = /(?:=|&#0*61;?|&#[xX]0*3[dD];?|&equals;)/;
 
 /////////////////////////////////////////////////////
@@ -337,7 +336,7 @@ ContextParserHandlebars.prototype.buildAst = function(input, i, sp) {
     } catch (exception) {
         if (typeof exception === 'string') {
             exceptionObj = new ContextParserHandlebarsException(
-                '[ERROR] ContextParserHandlebars: ' + exception,
+                '[ERROR] SecureHandlebars: ' + exception,
                 this.countNewLineChar(input.slice(0, j)), j);
             handlebarsUtils.handleError(exceptionObj, true);
         } else {
@@ -444,7 +443,7 @@ ContextParserHandlebars.prototype.analyzeAst = function(ast, contextParser, char
     if (leftParser && rightParser && 
             leftParser.state !== rightParser.state) {
         // debug("analyzeAst:["+r.parsers[0].state+"/"+r.parsers[1].state+"]");
-        msg = "[ERROR] ContextParserHandlebars: Inconsistent HTML5 state OR without close tag after conditional branches. Please fix your template! ("+leftParser.state+"/"+rightParser.state+")";
+        msg = "[ERROR] SecureHandlebars: Inconsistent HTML5 state OR without close tag after conditional branches. Please fix your template! ("+leftParser.state+"/"+rightParser.state+")";
         exceptionObj = new ContextParserHandlebarsException(msg, this._lineNo, this._charNo);
         handlebarsUtils.handleError(exceptionObj, true);
     }
@@ -509,7 +508,7 @@ ContextParserHandlebars.prototype.handleTemplate = function(input, i, stateObj) 
     } catch (exception) {
         if (typeof exception === 'string') {
             exceptionObj = new ContextParserHandlebarsException(
-                '[ERROR] ContextParserHandlebars: ' + exception,
+                '[ERROR] SecureHandlebars: ' + exception,
                 this._lineNo, 
                 this._charNo);
             handlebarsUtils.handleError(exceptionObj, true);
@@ -525,53 +524,30 @@ ContextParserHandlebars.prototype.handleTemplate = function(input, i, stateObj) 
 * @description
 * Add the filters to the escape expression based on the state.
 */
-ContextParserHandlebars.prototype.addFilters = function(stateObj, input) {
+ContextParserHandlebars.prototype.addFilters = function(parser, input) {
 
     /* transitent var */
-    var isFullUri, f, filters, exceptionObj, msgPrefix,
-        attributeName = stateObj.attributeName,
-        attributeValue = stateObj.attributeValue;
+    var isFullUri = false, filters = [], f, exceptionObj, msgPrefix,
+        state = parser.state,
+        tagName = parser.getStartTagName(),
+        attributeName = parser.attributeName,
+        attributeValue = parser.attributeValue;
 
     try {
-        switch(stateObj.state) {
+        switch(state) {
             case stateMachine.State.STATE_DATA: // 1
-                return [filter.FILTER_DATA];
             case stateMachine.State.STATE_RCDATA: // 3
                 return [filter.FILTER_DATA];
-            case stateMachine.State.STATE_RAWTEXT:  // 5
-                /* we use filter.FILTER_NOT_HANDLE to warn the developers for unsafe output expression,
-                * and we fall back to default Handlebars escaping filter. IT IS UNSAFE.
-                */
-                throw 'Unsafe output expression @ STATE_RAWTEXT state';
-            case stateMachine.State.STATE_SCRIPT_DATA: // 6
-                /* we use filter.FILTER_NOT_HANDLE to warn the developers for unsafe output expression,
-                * and we fall back to default Handlebars escaping filter. IT IS UNSAFE.
-                */
-                throw 'Unsafe output expression @ STATE_SCRIPT_DATA state.';
-            case stateMachine.State.STATE_BEFORE_ATTRIBUTE_NAME: // 34
-                /* never fall into state 34 */
-                throw 'Unexpected output expression @ STATE_BEFORE_ATTRIBUTE_NAME state';
-            case stateMachine.State.STATE_ATTRIBUTE_NAME: // 35
-                /* we use filter.FILTER_NOT_HANDLE to warn the developers for unsafe output expression,
-                * and we fall back to default Handlebars escaping filter. IT IS UNSAFE.
-                */
-                throw 'Unsafe output expression @ STATE_ATTRIBUTE_NAME state';
-            case stateMachine.State.STATE_AFTER_ATTRIBUTE_NAME: // 36
-                /* never fall into state 36 */
-                throw 'Unexpected output expression @ STATE_AFTER_ATTRIBUTE_NAME state';
-            case stateMachine.State.STATE_BEFORE_ATTRIBUTE_VALUE: // 37
-                /* never fall into state 37 */
-                throw 'Unexpected output expression @ STATE_BEFORE_ATTRIBUTE_VALUE state';
+
             case stateMachine.State.STATE_ATTRIBUTE_VALUE_DOUBLE_QUOTED: // 38
             case stateMachine.State.STATE_ATTRIBUTE_VALUE_SINGLE_QUOTED: // 39
             case stateMachine.State.STATE_ATTRIBUTE_VALUE_UNQUOTED: // 40
-                filters = [];
-                // URI scheme
-                if (uriAttributeNames[attributeName]) {
+
+                if (parser.isURIAttribute()) {
                     /* we don't support javascript parsing yet */
                     // TODO: this filtering rule cannot cover all cases.
                     if (handlebarsUtils.blacklistProtocol(attributeValue)) {
-                        throw 'Unsafe output expression @ attribute URI Javascript context';
+                        throw 'scriptable URI attribute (e.g., after <a href="javascript: )';
                     }
 
                     /* add the correct uri filter */
@@ -579,65 +555,77 @@ ContextParserHandlebars.prototype.addFilters = function(stateObj, input) {
                         isFullUri = true;
                         f = filter.FILTER_FULL_URI;
                     } else {
-                        isFullUri = false;
                         f = reEqualSign.test(attributeValue) ? filter.FILTER_ENCODE_URI_COMPONENT : filter.FILTER_ENCODE_URI;
                     }
-                    filters.push(f);
-
-                    /* add the attribute value filter */
-                    switch(stateObj.state) {
-                        case stateMachine.State.STATE_ATTRIBUTE_VALUE_DOUBLE_QUOTED:
-                            f = filter.FILTER_ATTRIBUTE_VALUE_DOUBLE_QUOTED;
-                            break;
-                        case stateMachine.State.STATE_ATTRIBUTE_VALUE_SINGLE_QUOTED:
-                            f = filter.FILTER_ATTRIBUTE_VALUE_SINGLE_QUOTED;
-                            break;
-                        default: // stateMachine.State.STATE_ATTRIBUTE_VALUE_UNQUOTED:
-                            f = filter.FILTER_ATTRIBUTE_VALUE_UNQUOTED;
-                    }
-                    filters.push(f);
-
-                    /* add blacklist filters at the end of filtering chain */
-                    if (isFullUri) {
-                        /* blacklist the URI scheme for full uri */
-                        filters.push(filter.FILTER_URI_SCHEME_BLACKLIST);
-                    }
-                    return filters;
+                    filters.push(f);                    
+                    
                 } else if (attributeName === "style") {  // CSS
                     /* we don't support css parser yet
                     * we use filter.FILTER_NOT_HANDLE to warn the developers for unsafe output expression,
                     * and we fall back to default Handlebars escaping filter. IT IS UNSAFE.
                     */
-                    throw 'Unsafe output expression @ attribute style CSS context';
+                    throw 'CSS style attribute';
                 } else if (attributeName.match(/^on/i)) { // Javascript
                     /* we don't support js parser yet
                     * we use filter.FILTER_NOT_HANDLE to warn the developers for unsafe output expression,
                     * and we fall back to default Handlebars escaping filter. IT IS UNSAFE.
                     */
-                    throw 'Unsafe output expression @ attribute on* Javascript context';
-                } else {
-                    /* add the attribute value filter */
-                    switch(stateObj.state) {
-                        case stateMachine.State.STATE_ATTRIBUTE_VALUE_DOUBLE_QUOTED:
-                            return [filter.FILTER_ATTRIBUTE_VALUE_DOUBLE_QUOTED];
-                        case stateMachine.State.STATE_ATTRIBUTE_VALUE_SINGLE_QUOTED:
-                            return [filter.FILTER_ATTRIBUTE_VALUE_SINGLE_QUOTED];
-                        default: // stateMachine.State.STATE_ATTRIBUTE_VALUE_UNQUOTED:
-                            return [filter.FILTER_ATTRIBUTE_VALUE_UNQUOTED];
-                    }
+                    throw attributeName + ' JavaScript event attribute';
                 }
-                break;
-            case stateMachine.State.STATE_AFTER_ATTRIBUTE_VALUE_QUOTED: // 42
-                /* never fall into state 42 */
-                throw 'Unsafe output expression @ STATE_AFTER_ATTRIBUTE_VALUE_QUOTED state';
+
+
+                /* add the attribute value filter */
+                switch(state) {
+                    case stateMachine.State.STATE_ATTRIBUTE_VALUE_DOUBLE_QUOTED:
+                        f = filter.FILTER_ATTRIBUTE_VALUE_DOUBLE_QUOTED;
+                        break;
+                    case stateMachine.State.STATE_ATTRIBUTE_VALUE_SINGLE_QUOTED:
+                        f = filter.FILTER_ATTRIBUTE_VALUE_SINGLE_QUOTED;
+                        break;
+                    default: // stateMachine.State.STATE_ATTRIBUTE_VALUE_UNQUOTED:
+                        f = filter.FILTER_ATTRIBUTE_VALUE_UNQUOTED;
+                }
+                filters.push(f);
+
+                /* add blacklist filters at the end of filtering chain */
+                if (isFullUri) {
+                    /* blacklist the URI scheme for full uri */
+                    filters.push(filter.FILTER_URI_SCHEME_BLACKLIST);
+                }
+                return filters;
+            
+
             case stateMachine.State.STATE_COMMENT: // 48
                 return [filter.FILTER_COMMENT];
+
+
+            /* the following are those unsafe contexts that we have no plans to support (yet?)
+             * we use filter.FILTER_NOT_HANDLE to warn the developers for unsafe output expression,
+             * and we fall back to default Handlebars escaping filter. IT IS UNSAFE.
+             */
+            case stateMachine.State.STATE_RAWTEXT:  // 5   // i.e., style, xmp, iframe, noembed, noframes tags
+                throw 'inside <' + tagName + '> tag (i.e., RAWTEXT state)';
+            case stateMachine.State.STATE_SCRIPT_DATA: // 6
+                throw 'inside <script> tag (i.e., SCRIPT_DATA state)';
+            case stateMachine.State.STATE_TAG_NAME: // 10
+                throw 'being an tag name (i.e., TAG_NAME state)';
+            case stateMachine.State.STATE_BEFORE_ATTRIBUTE_NAME: // 34
+            case stateMachine.State.STATE_ATTRIBUTE_NAME: // 35
+            case stateMachine.State.STATE_AFTER_ATTRIBUTE_NAME: // 36
+            case stateMachine.State.STATE_AFTER_ATTRIBUTE_VALUE_QUOTED: // 42
+                throw 'being an attribute name (state #: ' + state + ')';
+
+
+            // should not fall into the following states
+            case stateMachine.State.STATE_BEFORE_ATTRIBUTE_VALUE: // 37
+                throw 'unexpectedly BEFORE_ATTRIBUTE_VALUE state';
+
             default:
-                throw 'Unsafe output expression @ NOT HANDLE state:'+stateObj.state;
+                throw 'unsupported position (i.e., state #: ' + state + ')';
         }
     } catch (exception) {
         if (typeof exception === 'string') {
-            msgPrefix = this._config._strictMode? '[ERROR] ContextParserHandlebars:' : '[WARNING] ContextParserHandlebars:';
+            msgPrefix = (this._config._strictMode? '[ERROR]' : '[WARNING]') + ' SecureHandlebars: Unsafe output expression found at ';
             exceptionObj = new ContextParserHandlebarsException(
                 msgPrefix + exception,
                 this._lineNo,
@@ -699,7 +687,7 @@ ContextParserHandlebars.prototype.consumeExpression = function(input, i, type, s
         }
         saveToBuffer ? this.saveToBuffer(input[j]) : obj.str += input[j];
     }
-    throw "[ERROR] ContextParserHandlebars: Parsing error! Cannot encounter close brace of expression.";
+    throw "[ERROR] SecureHandlebars: Parsing error! Cannot encounter close brace of expression.";
 };
 
 /**
@@ -753,7 +741,7 @@ ContextParserHandlebars.prototype.handleEscapeExpression = function(input, i, le
             saveToBuffer ? this.saveToBuffer(input[j]) : obj.str += input[j];
         }
     }
-    msg = "[ERROR] ContextParserHandlebars: Parsing error! Cannot encounter '}}' close brace of escape expression.";
+    msg = "[ERROR] SecureHandlebars: Parsing error! Cannot encounter '}}' close brace of escape expression.";
     exceptionObj = new ContextParserHandlebarsException(msg, this._lineNo, this._charNo);
     handlebarsUtils.handleError(exceptionObj, true);
 };
@@ -781,10 +769,10 @@ ContextParserHandlebars.prototype.handleRawBlock = function(input, i, saveToBuff
         } else if (!isStartExpression && input[j] === '{' && j+4<len && input[j+1] === '{' && input[j+2] === '{' && input[j+3] === '{' && input[j+4] === '/') {
             re = handlebarsUtils.isValidExpression(input, j, handlebarsUtils.RAW_END_BLOCK);
             if (re.result === false) {
-                throw "[ERROR] ContextParserHandlebars: Parsing error! Invalid raw end block expression.";
+                throw "[ERROR] SecureHandlebars: Parsing error! Invalid raw end block expression.";
             }
             if (re.tag !== tag) {
-                throw "[ERROR] ContextParserHandlebars: Parsing error! start/end raw block name mismatch.";
+                throw "[ERROR] SecureHandlebars: Parsing error! start/end raw block name mismatch.";
             }
             for(var k=j;k<len;++k) {
                 if (input[k] === '}' && k+3<len && input[k+1] === '}' && input[k+2] === '}' && input[k+3] === '}') {
@@ -800,7 +788,7 @@ ContextParserHandlebars.prototype.handleRawBlock = function(input, i, saveToBuff
             saveToBuffer ? this.saveToBuffer(input[j]) : obj.str += input[j];
         }
     }
-    throw "[ERROR] ContextParserHandlebars: Parsing error! Cannot encounter '}}}}' close brace of raw block.";
+    throw "[ERROR] SecureHandlebars: Parsing error! Cannot encounter '}}}}' close brace of raw block.";
 };
 
 /* exposing it */

--- a/src/strict-context-parser.js
+++ b/src/strict-context-parser.js
@@ -621,6 +621,41 @@ StrictContextParser.prototype.getCurrentState = function() {
 };
 
 
+// TODO: support compound uri context at <meta http-equiv="refresh" content="seconds; url">, <img srcset="url 1.5x, url 2x">
+var uriAttributeNames = {
+    // we generally do not differentiate whether these attribtues are tag specific during matching for simplicity
+    'href':1, 'src':1,                    // for a, link, img, area, iframe, frame, video, object, embed ...
+    'background':1,                       // for body, table, tbody, tr, td, th, etc?
+    'action':1, 'formaction':1,           // for form, input, button
+    'cite':1,                             // for blockquote, del, ins, q
+    'poster':1, 'usemap':1, 'longdesc':1, // for img, object, video, source
+    'srcdoc':1,                           // for iframe
+    'manifest':1,                         // for html
+    'classid':1,                          // for object
+    'codebase':1,                         // for object, applet
+    'icon':1,                             // for command
+    'profile':1,                          // for head
+    'xmlns':1,                            // for svg, etc?
+    'xml:base':1, 'xlink:href':1,         // for xml-related
+    'data': {'object':1},
+    'value': {'param':1}
+};
+
+/**
+ * @function StrictContextParser#isURIAttribute
+ *
+ * @returns {boolean} true if the attribute is of URI type, false otherwise
+ *
+ * @description
+ * check if the attribute is of URI type
+ *
+ */
+StrictContextParser.prototype.isURIAttribute = function() {
+    // here,  uriAttrTags === 1 is a tag agnostic matching
+    // while, uriAttrTags[tagName] (=== 1) matches only those attribute of the given tagName
+    var uriAttrTags = uriAttributeNames[this.attributeName];
+    return uriAttrTags && (uriAttrTags === 1 || uriAttrTags[this.tagNames[0]]);
+};
 
 
 

--- a/src/strict-context-parser.js
+++ b/src/strict-context-parser.js
@@ -344,6 +344,7 @@ function StrictContextParser(config, listeners) {
         !config.disableCanonicalization && this.on('preWalk', Canonicalize).on('reWalk', Canonicalize);
         // disable IE conditional comments
         !config.disableIEConditionalComments && this.on('preWalk', DisableIEConditionalComments);
+        // TODO: rewrite IE <comment> tags
 
         // TODO: When a start tag token is emitted with its self-closing flag set, if the flag is not acknowledged when it is processed by the tree construction stage, that is a parse error.
         // TODO: When an end tag token is emitted with attributes, that is a parse error.
@@ -621,7 +622,6 @@ StrictContextParser.prototype.getCurrentState = function() {
 };
 
 
-// TODO: support compound uri context at <meta http-equiv="refresh" content="seconds; url">, <img srcset="url 1.5x, url 2x">
 var uriAttributeNames = {
     // we generally do not differentiate whether these attribtues are tag specific during matching for simplicity
     'href':1, 'src':1,                    // for a, link, img, area, iframe, frame, video, object, embed ...
@@ -629,7 +629,7 @@ var uriAttributeNames = {
     'action':1, 'formaction':1,           // for form, input, button
     'cite':1,                             // for blockquote, del, ins, q
     'poster':1, 'usemap':1, 'longdesc':1, // for img, object, video, source
-    'srcdoc':1,                           // for iframe
+    'folder':1,                           // for a
     'manifest':1,                         // for html
     'classid':1,                          // for object
     'codebase':1,                         // for object, applet
@@ -644,19 +644,43 @@ var uriAttributeNames = {
 /**
  * @function StrictContextParser#isURIAttribute
  *
- * @returns {boolean} true if the attribute is of URI type, false otherwise
+ * @returns {boolean} true if the attribute is likely of URI type, false otherwise
  *
  * @description
- * check if the attribute is of URI type
+ * Check if the current attribute is likely of URI type. This might not be accurate since it could be agnostic to its tag name (e.g., <x href="">)
  *
  */
 StrictContextParser.prototype.isURIAttribute = function() {
+    // TODO: support compound uri context at <meta http-equiv="refresh" content="seconds; url">, <img srcset="url 1.5x, url 2x">
+
     // here,  uriAttrTags === 1 is a tag agnostic matching
-    // while, uriAttrTags[tagName] (=== 1) matches only those attribute of the given tagName
+    // while, uriAttrTags[tagName] === 1 matches only those attribute of the given tagName
     var uriAttrTags = uriAttributeNames[this.attributeName];
-    return uriAttrTags && (uriAttrTags === 1 || uriAttrTags[this.tagNames[0]]);
+    return uriAttrTags && (uriAttrTags === 1 || uriAttrTags[this.tagNames[0]] === 1);
 };
 
+
+// <iframe srcdoc=""> is a scriptable attribute too
+// Reference: https://html.spec.whatwg.org/multipage/embedded-content.html#attr-iframe-srcdoc
+var scriptableTags = {
+    script:1,style:1,
+    svg:1,xml:1,math:1,
+    applet:1,object:1,embed:1,link:1,
+    scriptlet:1                  // IE-specific
+};
+
+/**
+ * @function StrictContextParser#isScriptableTag
+ *
+ * @returns {boolean} true if the current tag can possibly incur script either through configuring its attribute name or inner HTML
+ *
+ * @description
+ * Check if the current tag can possibly incur script either through configuring its attribute name or inner HTML
+ *
+ */
+StrictContextParser.prototype.isScriptableTag = function() {
+    return scriptableTags[this.tagNames[0]] === 1;
+};
 
 
 

--- a/tests/samples/files/handlebarsjs_filter_attr_value_uri_contexts.hbs
+++ b/tests/samples/files/handlebarsjs_filter_attr_value_uri_contexts.hbs
@@ -1,0 +1,29 @@
+{{! This file tests for the attribute value context }}
+
+<!-- uri contexts agnostic to tagname -->
+<x href="{{url01}}">
+<x src="{{url02}}">
+<x background="{{url03}}">
+<x action="{{url04}}">
+<x formaction="{{url05}}">
+<x cite="{{url06}}">
+<x poster="{{url07}}">
+<x usemap="{{url08}}">
+<x longdesc="{{url09}}">
+<x srcdoc="{{url10}}">
+<x manifest="{{url11}}">
+<x classid="{{url12}}">
+<x codebase="{{url13}}">
+<x icon="{{url14}}">
+<x profile="{{url15}}">
+<x xmlns="{{url16}}">
+<x xml:base="{{url17}}">
+<x xlink:href="{{url18}}">
+
+
+
+<!-- test for tag specific uri contexts -->
+<object data="{{url90}}">
+<param value="{{url91}}">
+<x data="{{url92}}">
+<x param="{{url93}}">

--- a/tests/samples/files/handlebarsjs_filter_attr_value_uri_contexts.hbs
+++ b/tests/samples/files/handlebarsjs_filter_attr_value_uri_contexts.hbs
@@ -10,7 +10,7 @@
 <x poster="{{url07}}">
 <x usemap="{{url08}}">
 <x longdesc="{{url09}}">
-<x srcdoc="{{url10}}">
+<x folder="{{url10}}">
 <x manifest="{{url11}}">
 <x classid="{{url12}}">
 <x codebase="{{url13}}">

--- a/tests/samples/files/handlebarsjs_template_strict_mode_003.hbs
+++ b/tests/samples/files/handlebarsjs_template_strict_mode_003.hbs
@@ -1,3 +1,6 @@
+<xmp>
+{{data_xmp}}
+</xmp>
 <style>
-{{data}}
+{{data_style}}
 </style>

--- a/tests/samples/files/handlebarsjs_template_strict_mode_008.hbs
+++ b/tests/samples/files/handlebarsjs_template_strict_mode_008.hbs
@@ -1,1 +1,1 @@
-<a{{data}}>
+<textarea>fasdf</{{data}}>

--- a/tests/test-patterns.js
+++ b/tests/test-patterns.js
@@ -1067,7 +1067,7 @@ var exceptionPatterns = [
         title: './bin/handlebarspp STATE_SCRIPT_DATA strict mode test',
         file: './tests/samples/files/handlebarsjs_template_strict_mode_001.hbs',
         strictMode: true,
-        result: [ /ERROR/, /SCRIPT_DATA/, ],
+        result: [ /ERROR/, /scriptable/, ],
     },
     {
         title: './bin/handlebarspp STATE_ATTRIBUTE_NAME strict mode test',
@@ -1079,7 +1079,7 @@ var exceptionPatterns = [
         title: './bin/handlebarspp STATE_RAWTEXT strict mode test',
         file: './tests/samples/files/handlebarsjs_template_strict_mode_003.hbs',
         strictMode: true,
-        result: [ /ERROR/, /RAWTEXT/ ],
+        result: [ /ERROR/, /scriptable <style> tag/ ],
     },
     {
         title: './bin/handlebarspp STATE_TAG_NAME strict mode test',

--- a/tests/test-patterns.js
+++ b/tests/test-patterns.js
@@ -734,7 +734,7 @@ var filterTemplatePatterns = [
         result: [ /{{{yd name}}}/, /{{{yc comment}}}/ ],
     },
     {
-        title: './bin/handlebarspp attribute value / URI state template filter test',
+        title: './bin/handlebarspp attribute value / URI state template filter test 1',
         file: './tests/samples/files/handlebarsjs_filter_attr_value_href.hbs',
         result: [ 
                   // test against double quoted, single quoted and unquoted URL in attribute href
@@ -759,19 +759,35 @@ var filterTemplatePatterns = [
         ],
     },
     {
-        title: './bin/handlebarspp attribute value / URI state template filter test',
+        title: './bin/handlebarspp attribute value / URI state template filter test 2',
         file: './tests/samples/files/handlebarsjs_filter_attr_value_src.hbs',
         result: [],
     },
     {
-        title: './bin/handlebarspp attribute value / URI state template filter test',
+        title: './bin/handlebarspp attribute value / URI state template filter test 3',
         file: './tests/samples/files/handlebarsjs_filter_attr_value_form_action.hbs',
         result: [],
     },
     {
-        title: './bin/handlebarspp attribute value / URI state template filter test',
+        title: './bin/handlebarspp attribute value / URI state template filter test 4',
         file: './tests/samples/files/handlebarsjs_filter_attr_value_button_formaction.hbs',
         result: [],
+    },
+    {
+        title: './bin/handlebarspp URI attribute test',
+        file: './tests/samples/files/handlebarsjs_filter_attr_value_uri_contexts.hbs',
+        result: [
+            /{{{yubl \(yavd \(yufull url01\)\)}}}/, /{{{yubl \(yavd \(yufull url02\)\)}}}/, /{{{yubl \(yavd \(yufull url03\)\)}}}/,
+            /{{{yubl \(yavd \(yufull url04\)\)}}}/, /{{{yubl \(yavd \(yufull url05\)\)}}}/, /{{{yubl \(yavd \(yufull url06\)\)}}}/,
+            /{{{yubl \(yavd \(yufull url07\)\)}}}/, /{{{yubl \(yavd \(yufull url08\)\)}}}/, /{{{yubl \(yavd \(yufull url09\)\)}}}/,
+            /{{{yubl \(yavd \(yufull url10\)\)}}}/, /{{{yubl \(yavd \(yufull url11\)\)}}}/, /{{{yubl \(yavd \(yufull url12\)\)}}}/,
+            /{{{yubl \(yavd \(yufull url13\)\)}}}/, /{{{yubl \(yavd \(yufull url14\)\)}}}/, /{{{yubl \(yavd \(yufull url15\)\)}}}/,
+            /{{{yubl \(yavd \(yufull url16\)\)}}}/, /{{{yubl \(yavd \(yufull url17\)\)}}}/, /{{{yubl \(yavd \(yufull url18\)\)}}}/,
+
+            // only add url filters to tag specific attribute
+            /{{{yubl \(yavd \(yufull url90\)\)}}}/, /{{{yubl \(yavd \(yufull url91\)\)}}}/, 
+            /{{{yavd url92}}}/, /{{{yavd url93}}}/
+        ]
     },
     {
         title: './bin/handlebarspp attribute value / CSS state (value string) template filter test',
@@ -1051,49 +1067,49 @@ var exceptionPatterns = [
         title: './bin/handlebarspp STATE_SCRIPT_DATA strict mode test',
         file: './tests/samples/files/handlebarsjs_template_strict_mode_001.hbs',
         strictMode: true,
-        result: [ /ERROR/, /STATE_SCRIPT_DATA/, ],
+        result: [ /ERROR/, /SCRIPT_DATA/, ],
     },
     {
         title: './bin/handlebarspp STATE_ATTRIBUTE_NAME strict mode test',
         file: './tests/samples/files/handlebarsjs_template_strict_mode_002.hbs',
         strictMode: true,
-        result: [ /ERROR/, /STATE_ATTRIBUTE_NAME/ ],
+        result: [ /ERROR/, /attribute name/ ],
     },
     {
         title: './bin/handlebarspp STATE_RAWTEXT strict mode test',
         file: './tests/samples/files/handlebarsjs_template_strict_mode_003.hbs',
         strictMode: true,
-        result: [ /ERROR/, /STATE_RAWTEXT/ ],
+        result: [ /ERROR/, /RAWTEXT/ ],
     },
     {
-        title: './bin/handlebarspp NOT HANDLE strict mode test',
+        title: './bin/handlebarspp STATE_TAG_NAME strict mode test',
         file: './tests/samples/files/handlebarsjs_template_strict_mode_004.hbs',
         strictMode: true,
-        result: [ /ERROR/, /NOT HANDLE/ ],
+        result: [ /ERROR/, /TAG_NAME/ ],
     },
     {
         title: './bin/handlebarspp attribute URI Javascript context strict mode test',
         file: './tests/samples/files/handlebarsjs_template_strict_mode_005.hbs',
         strictMode: true,
-        result: [ /ERROR/, /attribute URI Javascript context/ ],
+        result: [ /ERROR/, /scriptable URI/ ],
     },
     {
         title: './bin/handlebarspp attribute style CSS context strict mode test',
         file: './tests/samples/files/handlebarsjs_template_strict_mode_006.hbs',
         strictMode: true,
-        result: [ /ERROR/, /attribute style CSS context/ ],
+        result: [ /ERROR/, /CSS style attribute/ ],
     },
     {
         title: './bin/handlebarspp attribute on* Javascript context strict mode test',
         file: './tests/samples/files/handlebarsjs_template_strict_mode_007.hbs',
         strictMode: true,
-        result: [ /ERROR/, /attribute on\* Javascript context/ ],
+        result: [ /ERROR/, /JavaScript event attribute/ ],
     },
     {
         title: './bin/handlebarspp NOT HANDLE state strict mode test',
         file: './tests/samples/files/handlebarsjs_template_strict_mode_008.hbs',
         strictMode: true,
-        result: [ /ERROR/, /NOT HANDLE/ ],
+        result: [ /ERROR/, /unsupported/ ],
     },
 ];
 exports.exceptionPatterns = exceptionPatterns;


### PR DESCRIPTION
- more uri attributes. and some are matched specific to their tag names
- throw error/warning on placing output expressions in or as attribute of scriptable tags
- RAWTEXT tags including `<xmp>`, `<noframes>` and `<noembed>` will now incur no warning/errors and keep using y filter
- make error messages more readable