### PR TITLE
Improve release workflow

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -92,9 +92,27 @@ module.exports = function(grunt) {
         }
       }
     },
+    bump: {
+      options: {
+        files: [ 'package.json', 'bower.json'],
+        updateConfigs: ['pkg'],
+        commit: true,
+        commitMessage: 'Release v%VERSION%',
+        commitFiles: ['package.json', 'bower.json', 'dist/.'],
+        createTag: true,
+        tagName: 'v%VERSION%',
+        tagMessage: 'Version %VERSION%',
+        push: true,
+        pushTo: 'origin',
+        gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
+        globalReplace: false,
+        prereleaseName: false,
+        regExp: false
+      }
+    },
     clean: {
-      all: ['xunit.xml', 'artifacts', 'coverage', 'node_modules'],
-      buildResidues: ['xunit.xml', 'artifacts', 'coverage']
+      all: ['artifacts', 'coverage', 'node_modules'],
+      buildResidues: ['artifacts', 'coverage']
     }
   });
 
@@ -105,9 +123,11 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-execute');
+  grunt.loadNpmTasks('grunt-bump');
 
   grunt.registerTask('test', ['clean:buildResidues', 'jshint', 'execute', 'dist', 'karma', 'mocha_istanbul']);
   grunt.registerTask('dist', ['browserify', 'uglify']);
   grunt.registerTask('default', ['test']);
+  grunt.registerTask('release', ['bump-only', 'dist', 'bump-commit'])
 
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,6 +51,10 @@ module.exports = function(grunt) {
       buildMin: {
         src: ['src/polyfills/*.js', 'dist/<%= pkg.name %>.js'],
         dest: 'dist/<%= pkg.name %>.min.js'
+      },
+      buildMinWithVersion: {
+        src: ['src/polyfills/*.js', 'dist/<%= pkg.name %>.js'],
+        dest: 'dist/<%= pkg.name %>.<%= pkg.version %>.min.js'
       }
     },
     karma: {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,6 @@
 {
   "name": "secure-handlebars",
   "version": "1.1.1",
-  "licenses": [
-    {
-      "type": "BSD",
-      "url": "https://github.com/yahoo/secure-handlebars/blob/master/LICENSE"
-    }
-  ],
   "author": "Nera Liu",
   "contributors": [
     "Nera Liu <neraliu@yahoo-inc.com>",
@@ -51,6 +45,7 @@
     "chai": "^2.3.0",
     "grunt-bower-task": "^0.4.0",
     "grunt-browserify": "^3.3.0",
+    "grunt-bump": "^0.3.1",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-jshint": "^0.11.0",
@@ -71,5 +66,5 @@
   "directories": {
     "test": "tests"
   },
-  "license": "BSD"
+  "license": "SEE LICENSE IN LICENSE"
 }


### PR DESCRIPTION
thereafter, the task of releasing a new version becomes easier.

To release a version
 - `grunt release` will automatically set version z=z+1 as in x.y.z
 - `grunt release minor` will automatically set version y = y+1, z = 0 as in x.y.z
 - `grunt release major` will automatically set version x = x+1, y = z = 0 as in x.y.z

p.s. append ` --dry-run` if needed for a test. 

What it does:
 - the new version number will be written into both package.json and bower.json
 - call `grunt dist` to generate a new file (with proper version #)
 - `git commit package.json, bower.json, dist/. -m "Release vx.y.z"`
 - `git tag -a vx.y.z -m "Version x.y.z"`
 - `git push origin && git push origin --tags`
